### PR TITLE
Fall back config path

### DIFF
--- a/src/pasfetch.pas
+++ b/src/pasfetch.pas
@@ -20,7 +20,7 @@ var
     FFormatString: String;
     tmp: TStringDynArray;
     i: Integer;
-    UseXDGVar: Boolean;
+    ConfigPath: String;
 
 function Uptime: String;
 var
@@ -187,29 +187,22 @@ begin
 
     if GetEnv('XDG_CONFIG_HOME') <> '' then
     begin
-    	FConfig := TIniFile.Create(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini');
-	    UseXDGVar := true;
+        ConfigPath := GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini'
     end
     else 
     begin
-    	FConfig := TIniFile.Create(GetEnv('HOME')+'/.config/pasfetch/config.ini');
-	    UseXDGVar := false;
+        ConfigPath := GetEnv('HOME')+'/.config/pasfetch/config.ini'
     end;
+    
+    FConfig := TIniFile.Create(ConfigPath);
 
-    if not FileExists(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini') or FileExists(GetEnv('HOME')+'/.config/pasfetch/config.ini') then
+    if not FileExists(ConfigPath+'/pasfetch/config.ini') then
     begin
         writeln('No config File present, creating...');
         FConfig.WriteBool('PASFETCH', 'color', True);
         FConfig.WriteBool('PASFETCH', 'useratmachine', True);
         FConfig.WriteString('PASFETCH', 'INFOS', 'fl:OS fl:KERNEL env:SHELL');
-        if UseXDGVar then 
-        begin
-            writeln('Created '+GetEnv('XDG_CONFIG_HOME')+'/.config/pasfetch/config.ini');
-        end
-        else
-        begin
-            writeln('Created '+GetEnv('HOME')+'/.config/pasfetch/config.ini');
-        end
+        writeln('Created '+ConfigPath);
     end;
 
     FUserAtMachine := FConfig.ReadBool('PASFETCH', 'useratmachine', True);

--- a/src/pasfetch.pas
+++ b/src/pasfetch.pas
@@ -168,7 +168,7 @@ begin
         writeln('pasfetch - System Information Fetcher written in Pascal.');
         writeln();
         writeln('Usage: pasfetch');
-        writeln('Config: $XDG_CONFIG_HOME/pasfetch/config.ini (created on first run)');
+        writeln('Config: ${XDG_CONFIG_HOME:-$HOME/.config}/pasfetch/config.ini (created on first run)');
         writeln('Supported Infos:');
         writeln('- All Environment Variables');
         writeln('- fl:OS     Operating System');

--- a/src/pasfetch.pas
+++ b/src/pasfetch.pas
@@ -20,6 +20,7 @@ var
     FFormatString: String;
     tmp: TStringDynArray;
     i: Integer;
+    UseXDGVar: Boolean;
 
 function Uptime: String;
 var
@@ -184,14 +185,31 @@ begin
     FOSName := GetOsName();
     FLogo := SplitString(Logos.GetLogo(FOSName), sLineBreak);
 
-    FConfig := TIniFile.Create(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini');
+    if GetEnv('XDG_CONFIG_HOME') <> '' then
+    begin
+    	FConfig := TIniFile.Create(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini');
+	    UseXDGVar := true;
+    end
+    else 
+    begin
+    	FConfig := TIniFile.Create(GetEnv('HOME')+'/.config/pasfetch/config.ini');
+	    UseXDGVar := false;
+    end;
+
     if not FileExists(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini') or FileExists(GetEnv('HOME')+'/.config/pasfetch/config.ini') then
     begin
         writeln('No config File present, creating...');
         FConfig.WriteBool('PASFETCH', 'color', True);
         FConfig.WriteBool('PASFETCH', 'useratmachine', True);
         FConfig.WriteString('PASFETCH', 'INFOS', 'fl:OS fl:KERNEL env:SHELL');
-        writeln('Created '+GetEnv('HOME')+'/.config/pasfetch/config.ini');
+        if UseXDGVar then 
+        begin
+            writeln('Created '+GetEnv('XDG_CONFIG_HOME')+'/.config/pasfetch/config.ini');
+        end
+        else
+        begin
+            writeln('Created '+GetEnv('HOME')+'/.config/pasfetch/config.ini');
+        end
     end;
 
     FUserAtMachine := FConfig.ReadBool('PASFETCH', 'useratmachine', True);

--- a/src/pasfetch.pas
+++ b/src/pasfetch.pas
@@ -184,8 +184,8 @@ begin
     FOSName := GetOsName();
     FLogo := SplitString(Logos.GetLogo(FOSName), sLineBreak);
 
-    FConfig := TIniFile.Create(GetEnv('HOME')+'/.config/pasfetch/config.ini');
-    if not FileExists(GetEnv('HOME')+'/.config/pasfetch/config.ini') then
+    FConfig := TIniFile.Create(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini');
+    if not FileExists(GetEnv('XDG_CONFIG_HOME')+'/pasfetch/config.ini') or FileExists(GetEnv('HOME')+'/.config/pasfetch/config.ini') then
     begin
         writeln('No config File present, creating...');
         FConfig.WriteBool('PASFETCH', 'color', True);


### PR DESCRIPTION
If `XDG_CONFIG_HOME` is not defined, fall back to the location `$HOME/.config`.